### PR TITLE
Return error from github client when response is not 2XX

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -37,6 +37,10 @@ func (g GithubClient) ExecuteGithubApi(url string, method string, authorizationH
 		return nil, fmt.Errorf("failed to read from git api command %s: %s", removeSecretsFromOutputs(err.Error(), authorizationHeaders), removeSecretsFromOutputs(string(response), authorizationHeaders))
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("error: status code: %d, response: %s", resp.StatusCode, response)
+	}
+
 	return response, nil
 }
 
@@ -54,7 +58,7 @@ func (g GithubClient) ExecuteGithubCmd(param ...string) (string, error) {
 	return string(output), nil
 }
 
-func (g GithubClient) ExecuteGithubGetApi(url string, token string) ([]byte, error) {
+func (g GithubClient) ExecuteGithubGetApi(url string) ([]byte, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute git get call %w", err)
@@ -65,6 +69,9 @@ func (g GithubClient) ExecuteGithubGetApi(url string, token string) ([]byte, err
 		return nil, fmt.Errorf("failed to read from git api call %w", err)
 	}
 
-	return body, nil
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("error: status code: %d, response: %s", resp.StatusCode, body)
+	}
 
+	return body, nil
 }

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1,0 +1,85 @@
+package github_test
+
+import (
+	"fmt"
+	"github.com/pivotal/create-pull-request-resource/github"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGithub(t *testing.T) {
+	spec.Run(t, "TestGithub", testGithub, spec.Report(report.Terminal{}))
+}
+
+func testGithub(t *testing.T, when spec.G, it spec.S) {
+	var (
+		client       github.GithubClient
+		githubServer *httptest.Server
+	)
+
+	it.Before(func() {
+		client = github.GithubClient{}
+
+		githubServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/200":
+				w.WriteHeader(200)
+				fmt.Fprint(w, "response from github")
+			case "/400":
+				w.WriteHeader(400)
+				fmt.Fprint(w, "error message from github")
+			default:
+				require.Fail(t, "Unexpected path: %s", r.URL.Path)
+			}
+		}))
+	})
+
+	it.After(func() {
+		githubServer.Close()
+	})
+
+	when("ExecuteGithubApi", func() {
+		when("github returns a 2XX response", func() {
+			it("returns the response body", func() {
+				response, err := client.ExecuteGithubApi(githubServer.URL+"/200", "GET", "", nil)
+
+				require.NoError(t, err)
+				assert.Equal(t, "response from github", string(response))
+			})
+		})
+
+		when("github returns a non-2XX response", func() {
+			it("returns an error", func() {
+				_, err := client.ExecuteGithubApi(githubServer.URL+"/400", "GET", "", nil)
+
+				assert.Error(t, err)
+				assert.Equal(t, "error: status code: 400, response: error message from github", err.Error())
+			})
+		})
+	})
+
+	when("ExecuteGithubGetApi", func() {
+		when("github returns a 2XX response", func() {
+			it("returns the response body", func() {
+				response, err := client.ExecuteGithubGetApi(githubServer.URL + "/200")
+
+				require.NoError(t, err)
+				assert.Equal(t, "response from github", string(response))
+			})
+		})
+
+		when("github returns a non-2XX response", func() {
+			it("returns an error", func() {
+				_, err := client.ExecuteGithubGetApi(githubServer.URL + "/400")
+
+				assert.Error(t, err)
+				assert.Equal(t, "error: status code: 400, response: error message from github", err.Error())
+			})
+		})
+	})
+}

--- a/in/main.go
+++ b/in/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	url := fmt.Sprintf("https://api.github.com/repos/%s/pulls/%s", request.Source.RemoteRepository, request.Version.Ref)
 
-	apiOutput, err := client.ExecuteGithubGetApi(url, request.Source.GithubToken)
+	apiOutput, err := client.ExecuteGithubGetApi(url)
 	if err != nil {
 		log.Fatalf("Could not make a request for listing the newly create PR: %s", err.Error())
 	}
@@ -39,5 +39,5 @@ func main() {
 
 	inPutResponse := fmt.Sprintf(`{ "version": { "ref": "%s" },"metadata": [{"sha":"%s"}]}`, request.Version.Ref, pullRequestContent.Head.SHA)
 
-	fmt.Println(string(inPutResponse))
+	fmt.Println(inPutResponse)
 }


### PR DESCRIPTION
Otherwise the command will appear successful even if the response is something like a 403.

This also removes the `token` param from `ExecuteGithubGetApi` since it is unused.