### PR TITLE
Only put user in `head` if PR is coming from a different repo

### DIFF
--- a/pullRequest/PullRequest.go
+++ b/pullRequest/PullRequest.go
@@ -81,8 +81,11 @@ func (p PullRequest) createRemoteBranch(repo, location, accessToken string, clie
 func (p PullRequest) createPullRequestFor(branchName string, sourceRepo, remoteRepo, accessToken string, client github.Client) (PrRespeonse, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/pulls", remoteRepo)
 
-	githubUser := strings.Split(sourceRepo, "/")[0]
-	branchName = fmt.Sprintf("%s:%s", githubUser, branchName)
+	if sourceRepo != remoteRepo {
+		githubUser := strings.Split(sourceRepo, "/")[0]
+		branchName = fmt.Sprintf("%s:%s", githubUser, branchName)
+	}
+
 	body, _ := json.Marshal(map[string]string{
 		"title": p.Title,
 		"body":  p.Description,

--- a/pullRequest/PullRequest_test.go
+++ b/pullRequest/PullRequest_test.go
@@ -53,7 +53,7 @@ func testCreatePullRequestTask(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, jsonActualBody["title"], "A new PR")
 			assert.Equal(t, jsonActualBody["body"], description)
 			assert.Equal(t, jsonActualBody["base"], "master")
-			assert.Equal(t, jsonActualBody["head"], "test-org:"+branchName)
+			assert.Equal(t, jsonActualBody["head"], branchName)
 		})
 		it("apply the default values if not provided", func() {
 			pr := NewPullRequest("", "", "", "", false)
@@ -81,7 +81,7 @@ func testCreatePullRequestTask(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, prNumber, 12345)
 			assert.Equal(t, jsonActualBody["body"], "This is default description of the PR")
 			assert.Equal(t, jsonActualBody["base"], "master")
-			assert.Equal(t, jsonActualBody["head"], "test-org:"+branchName)
+			assert.Equal(t, jsonActualBody["head"], branchName)
 		})
 		it("apply the few default values if not provided", func() {
 			pr := NewPullRequest("This is the description of new PR by test", "Changing the version string to 12 from 14", "", "", false)
@@ -110,7 +110,7 @@ func testCreatePullRequestTask(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(t, jsonActualBody["title"], pr.Title)
 			assert.Equal(t, jsonActualBody["body"], pr.Description)
 			assert.Equal(t, jsonActualBody["base"], "master")
-			assert.Equal(t, jsonActualBody["head"], "test-org:"+branchName)
+			assert.Equal(t, jsonActualBody["head"], branchName)
 		})
 	})
 	when("auto merge is true", func() {


### PR DESCRIPTION
The request fails if the user is included and the PR branch is in the same repo it is being merged in to